### PR TITLE
Add GitHub Actions workflow to update README commits table

### DIFF
--- a/workflows/update-readme.yml
+++ b/workflows/update-readme.yml
@@ -1,0 +1,34 @@
+name: Update README Commits Table
+
+on:
+  schedule:
+    - cron: '0 * * * *' # Runs every hour
+  workflow_dispatch:    # Allows manual trigger from GitHub UI
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run update script
+        env:
+            APP_ID: ${{ secrets.APP_ID }}
+            PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+            INSTALLATION_ID: ${{ secrets.INSTALLATION_ID }}
+            TARGET_OWNER: ${{ vars.TARGET_OWNER }}
+            TARGET_REPO: ${{ vars.TARGET_REPO }}
+            TARGET_README_PATH: ${{ vars.TARGET_README_PATH }}
+            SOURCE_OWNER: ${{ vars.SOURCE_OWNER }}
+            SOURCE_TOPIC: ${{ vars.SOURCE_TOPIC }}
+        run: npm start


### PR DESCRIPTION
Introduce a scheduled GitHub Actions workflow that updates the README commits table every hour and allows for manual triggering.