### PR TITLE
Update workflow schedule to run on the 1st and 15th of each month

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -2,7 +2,7 @@ name: Update README Commits Table
 
 on:
   schedule:
-    - cron: '0 * * * *' # Runs every hour
+    - cron: '0 0 1,15 * *'
   workflow_dispatch:    # Allows manual trigger from GitHub UI
 
 jobs:


### PR DESCRIPTION
This pull request updates the schedule for the GitHub Actions workflow that updates the README commits table. The workflow will now run twice a month instead of every hour.

* Changed the cron schedule in `.github/workflows/update-readme.yml` to run at midnight on the 1st and 15th of each month instead of every hour.